### PR TITLE
Update Metrics Payload Structure

### DIFF
--- a/metrics/default-mobile-app-metrics.md
+++ b/metrics/default-mobile-app-metrics.md
@@ -60,14 +60,16 @@ Receives `Content-Type: application/json` containing JSON with following schema:
 {
   "clientId": "453de743207a0232a339a23e5d64b289",
   "timestamp": "8377194421",
-  "app": {
-    "id": "com.example.someApp",
-    "sdkVersion": "2.4.6",
-    "appVersion": "256"
-  },
-  "device": {
-    "platform": "android",
-    "platformVersion": "27"
+  "data": {
+    "app": {
+      "id": "com.example.someApp",
+      "sdkVersion": "2.4.6",
+      "appVersion": "256"
+    },
+    "device": {
+      "platform": "android",
+      "platformVersion": "27"
+    }
   }
 }
 ```


### PR DESCRIPTION
After some discussion with @aliok  (who did lots of research around the mobile metrics and built the PoC), We've decided to go with the approach of storing the metrics data in a JSONB column called `data`. The proposed structure here would be the simplest to parse into a struct (in Golang), to strip out undesired fields and do validation.

ping @danielpassos @wtrocki 